### PR TITLE
Ignore unknown properties when deserializing response bodies

### DIFF
--- a/net.adoptopenjdk.v3.vanilla/src/main/java/net/adoptopenjdk/v3/vanilla/internal/AOV3ObjectMappers.java
+++ b/net.adoptopenjdk.v3.vanilla/src/main/java/net/adoptopenjdk/v3/vanilla/internal/AOV3ObjectMappers.java
@@ -33,6 +33,7 @@ public final class AOV3ObjectMappers
     final JsonMapper mapper =
       JsonMapper.builder()
         .configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
         .build();
 
     final var deserializers = AOV3Deserializers.create();

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
       <url>http://io7m.com</url>
     </developer>
   </developers>
+  <contributors>
+    <contributor>
+      <name>Jochen Schalanda</name>
+      <email>jochen@schalanda.name</email>
+      <url>https://github.com/joschi/</url>
+    </contributor>
+  </contributors>
 
   <issueManagement>
     <url>http://github.com/AdoptOpenJDK/openjdk-api-java-client/issues</url>


### PR DESCRIPTION
In order to avoid breaking the client when a new property was added to the responses of the AdoptOpenJDK API, this PR disables the behavior of Jackson to fail on unknown properties.

https://github.com/FasterXML/jackson-docs/wiki/JacksonHowToIgnoreUnknown

Refs #6